### PR TITLE
Configure this project to be consumed by Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,24 @@
+{
+    "name": "jQuery-Tag-This",
+    "version": "0.0.0",
+    "homepage": "http://www.dangribbin.net/jquery-tag-this",
+    "authors": [
+        "Dan Gribbin <@dangribbin>"
+    ],
+    "description": "A jQuery plugin to make tags from text!",
+    "main": "src/jquery.tagthis.js",
+    "keywords": [
+        "jQuery",
+        "tag",
+        "jQuery-Tag-This",
+        "Tag-This"
+    ],
+    "license": "MIT",
+    "ignore": [
+        "**/.*",
+        "node_modules",
+        "bower_components",
+        "test",
+        "tests"
+    ]
+}


### PR DESCRIPTION
This PR adds a `bower.json` file to your project, allowing anyone using the Bower package manager to easily integrate the plugin into their application.

In addition to merging this code, you'll need to [register this package with Bower](http://bower.io/#registering-packages) by running `bower register jQuery-Tag-This https://github.com/dangribbin/jQuery-Tag-This`. Also, in order to use this you'll need to start tracking your releases with [semantic versioning](http://semver.org/), that way package managers like these don't get confused.
