### PR TITLE
converting input to a text area to deal with ie newline paste bug

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,27 +1,28 @@
 {
-    "name": "jQuery-Tag-This",
-    "version": "1.2.0",
-    "homepage": "http://www.dangribbin.net/jquery-tag-this",
-    "authors": [
-        "Dan Gribbin <@dangribbin>"
-    ],
-    "description": "A jQuery plugin to make tags from text!",
-    "main": "src/jquery.tagthis.js",
-    "keywords": [
-        "jQuery",
-        "tag",
-        "jQuery-Tag-This",
-        "Tag-This"
-    ],
-    "license": "MIT",
-    "ignore": [
-        "**/.*",
-        "node_modules",
-        "bower_components",
-        "test",
-        "tests"
-    ],
-    "dependencies": {
-        "jquery": ">= 1.11.0"
-    }
+  "name": "jQuery-Tag-This",
+  "version": "1.2.0",
+  "homepage": "http://www.dangribbin.net/jquery-tag-this",
+  "authors": [
+    "Dan Gribbin <@dangribbin>"
+  ],
+  "description": "A jQuery plugin to make tags from text!",
+  "main": "src/jquery.tagthis.js",
+  "keywords": [
+    "jQuery",
+    "tag",
+    "jQuery-Tag-This",
+    "Tag-This"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "jquery": ">= 1.11.0",
+    "jQuery-Tag-This": "https://github.com/herrmann-intl/jQuery-Tag-This"
+  }
 }

--- a/src/jquery-tag-this.css
+++ b/src/jquery-tag-this.css
@@ -1,77 +1,77 @@
-.tag-this { 
-    border:1px solid #CCC; 
-    background: #FFF; 
-    padding:5px; 
-    width:320px; 
-    height:100px; 
-    overflow-y: auto; 
+.tag-this {
+    border:1px solid #CCC;
+    background: #FFF;
+    padding:5px;
+    width:320px;
+    height:100px;
+    overflow-y: auto;
     margin: 20px 20px 20px 0;
     border-radius: 2px;
     -webkit-border-radius: 2px;
     -moz-border-radius: 2px;
 }
 
-.tag-this .tag { 
-    -moz-border-radius:2px; 
-    -webkit-border-radius:2px; 
-    border-radius: 2px; 
-    display: block; 
-    float: left; 
-    padding: 5px; 
-    text-decoration:none; 
-    background: #3AAA55; 
-    color: #FFF; 
-    margin-right: 5px; 
+.tag-this .tag {
+    -moz-border-radius:2px;
+    -webkit-border-radius:2px;
+    border-radius: 2px;
+    display: block;
+    float: left;
+    padding: 5px;
+    text-decoration:none;
+    background: #3AAA55;
+    color: #FFF;
+    margin-right: 5px;
     margin-bottom:5px;
     font-family: tahoma, sans-serif;
-    font-size:13px; 
+    font-size:13px;
     max-width: 90%;
 }
 
-.tag-this .tag button { 
-    font-weight: bold; 
-    color: #FFF; 
-    text-decoration:none; 
-    font-size: 11px; 
-    background: none; 
-    border: none; 
-    cursor: pointer; 
-} 
+.tag-this .tag button {
+    font-weight: bold;
+    color: #FFF;
+    text-decoration:none;
+    font-size: 11px;
+    background: none;
+    border: none;
+    cursor: pointer;
+}
 
-.tag-this .tag span { 
+.tag-this .tag span {
     word-wrap: break-word;
 }
 
-.tag-this input { 
-    padding: 6px; 
+.tag-this input, .tag-this textarea { 
+    padding: 6px;
     width:80px;
-    margin:0px; 
-    font-family: tahoma, sans-serif; 
-    font-size: 13px; 
+    margin:0px;
+    font-family: tahoma, sans-serif;
+    font-size: 13px;
     border:1px solid transparent;
     background: transparent;
     color: #000;
-    margin-right:5px; 
-    margin-bottom:5px; 
+    margin-right:5px;
+    margin-bottom:5px;
     outline-color: white;
 }
 
-.tag-this div { 
-    display:block; 
-    float: left; 
+.tag-this div {
+    display:block;
+    float: left;
 }
 
-.tag-this .tag-this--clear { 
+.tag-this .tag-this--clear {
     clear: both;
-    width: 100%; 
-    height: 0px; 
+    width: 100%;
+    height: 0px;
 }
 
 .tag-this .tag-this--invalid {
     /*background: #DF3645; */
     border: 1px dashed #DF3645;
     outline: white;
-    color: #DF3645; 
+    color: #DF3645;
     border-radius: 5px;
     outline-color:#DF3645;
 }

--- a/src/jquery.tagthis.js
+++ b/src/jquery.tagthis.js
@@ -76,7 +76,7 @@
             }
 
             if (settings.interactive) {
-                html = html + '<input id="'+id+'--tag" value="" data-default="'+ settings.defaultText +'" />';
+                html = html + '<textarea id="'+id+'--tag" value="" data-default="'+ settings.defaultText +'" />';
             }
 
             html = html + '</div><div class="tag-this--clear"></div></div><div class="tag-this--error"></div>';


### PR DESCRIPTION
All versions of IE have a very obnoxious "bug" that crops up when using this library. When you try to paste a multi-line string into an input field, it drops all but the first line of content.

This creates issues for users copying and pasting email addresses from excel into a tag-this field. Fortunately this is easily fixed by using a textarea instead an input field. 

This pull request swaps out the internal "fakeInputElement" with a text area.